### PR TITLE
Fix intake catalog

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ A package to build intake catalogs for cmip5, cmip6 and cordex data holdings
 Installing
 ----------
 
-Create a clone of the repository: 
+Create a clone of the repository:
 
 ``git clone https://github.com/roocs/catalog-maker.git``
 
@@ -172,9 +172,11 @@ It will have the name ``c3s.yml`` and will contain the below for each project sc
       c3s-cmip6:
         args:
           urlpath:
-        cache:
-        - argkey: urlpath
-          type: file
+        csv_kwargs:
+          blocksize: null
+          compression: gzip
+          dtype:
+            level: object
         description: c3s-cmip6 datasets
         driver: intake.source.csv.CSVSource
         metadata:

--- a/catalog_maker/catalog.py
+++ b/catalog_maker/catalog.py
@@ -162,7 +162,12 @@ def update_catalog(project, path, last_updated, cat_dir):
         f"{project}": {
             "description": f"{project} datasets",
             "driver": "intake.source.csv.CSVSource",
-            "cache": [{"argkey": "urlpath", "type": "file"}],
+            # "cache": [{"argkey": "urlpath", "type": "file"}],
+            "csv_kwargs": {
+                "blocksize": None,
+                "compression": "gzip",
+                "dtype": {"level": "object"},
+            },
             "args": {"urlpath": ""},
             "metadata": {"last_updated": ""},
         }

--- a/environment.yml
+++ b/environment.yml
@@ -10,3 +10,8 @@ dependencies:
   - xarray>=0.16
   - pandas
   - psycopg2
+  # tests
+  - pytest
+  - flake8
+  - watchdog
+  - sphinx

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,12 @@
+# conda env create -f environment.yml
+name: catalog_maker
+channels:
+  - conda-forge
+dependencies:
+  - pip
+  # open xarray results
+  - netcdf4
+  - numpy
+  - xarray>=0.16
+  - pandas
+  - psycopg2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,14 +1,14 @@
-pip==19.2.3
-bump2version==0.5.11
-wheel==0.33.6
-watchdog==0.9.0
-flake8==3.7.8
-tox==3.14.0
-coverage==4.5.4
-Sphinx==1.8.5
-twine==1.14.0
-pre-commit==2.8.2
+pip>=19.2.3
+bump2version>=0.5.11
+wheel>=0.33.6
+watchdog>=0.9.0
+flake8>=3.7.8
+tox>=3.14.0
+coverage>=4.5.4
+Sphinx>=1.8.5
+twine>=1.14.0
+pre-commit>=2.8.2
 
-pytest==4.6.5
-pytest-runner==5.1
-GitPython==3.1.12
+pytest>=4.6.5
+pytest-runner>=5.1
+GitPython>=3.1.12


### PR DESCRIPTION
This PR updates the intake yaml catalog and adds arguments for the `csv ` driver. This is necessary to make the yaml catalog readable by the latest versions of `intake`, `fsspec` and `dask`.

See issue https://github.com/roocs/rook/issues/173

The currently used yaml catalog for cmip6 will be updated manually with this PR:
https://github.com/cp4cds/c3s_34g_manifests/pull/17

A test for the `update_catalog` method is added and a conda `environment.yml`.